### PR TITLE
Add UNIOS loader

### DIFF
--- a/loaders/implementations/unios.py
+++ b/loaders/implementations/unios.py
@@ -1,0 +1,20 @@
+import json
+
+from radio.utils.normalize import split_artist_title
+from .common import timestamp_ms
+
+async def load(session):
+    url = "http://radio.unios.hr:8000/json.xsl"
+    response = await session.get(url, params={
+        '_': timestamp_ms()
+    })
+    jsonp_data = await response.text()
+
+    data = json.loads(jsonp_data.split("(", 1)[1].strip(");"))
+
+    artist_song = data["/fm.mp3"]["title"]
+
+    if "OFF AIR" in artist_song or "Radio UNIOS" in artist_song:
+        return None
+
+    return split_artist_title(artist_song)


### PR DESCRIPTION
This PR adds support for [Radio UNIOS](http://radio.unios.hr/)

Unfortunately, the AJAX call from frontend is a JSONP request meaning we had to strip out the function call part and then parse the JSON.

<details>
  <summary>JSONP Response example from http://radio.unios.hr:8000/json.xsl</summary>
  
  Response (prettified):
  
  ```js
  parseMusic(
    {
      "/fm.mp3": {
        "server_name": "fm.mp3",
        "listeners": "1",
        "description": "Radio UNIOS FM",
        "title": "Jimi Hendrix - Little Wing",
        "genre": "Misc",
        "bitrate": "192",
        "url": "radio.unios.hr"
      },
      ...
    }
  );
  ```
</details>

The JSON contains different streams, after some digging I found that we are interested in the "/fm.mp3" handle for the actual stream that is broadcasted on 107.8 MHz in Osijek.
